### PR TITLE
server: add config variables for blocking logins and registrations

### DIFF
--- a/freighter-server/src/api.rs
+++ b/freighter-server/src/api.rs
@@ -238,9 +238,13 @@ async fn register<I, S, A>(
 where
     A: AuthProvider,
 {
-    let token = state.auth.register(&auth.username, &auth.password).await?;
+    if state.config.allow_registration {
+        let token = state.auth.register(&auth.username, &auth.password).await?;
 
-    Ok(Html(token))
+        Ok(Html(token))
+    } else {
+        Err(StatusCode::UNAUTHORIZED.into())
+    }
 }
 
 async fn login<I, S, A>(
@@ -250,9 +254,13 @@ async fn login<I, S, A>(
 where
     A: AuthProvider,
 {
-    let token = state.auth.login(&auth.username, &auth.password).await?;
+    if state.config.allow_login {
+        let token = state.auth.login(&auth.username, &auth.password).await?;
 
-    Ok(Html(token))
+        Ok(Html(token))
+    } else {
+        Err(StatusCode::UNAUTHORIZED.into())
+    }
 }
 
 async fn search<I, S, A>(

--- a/freighter-server/src/lib.rs
+++ b/freighter-server/src/lib.rs
@@ -29,6 +29,10 @@ pub struct ServiceConfig {
     pub download_endpoint: String,
     pub api_endpoint: String,
     pub metrics_address: SocketAddr,
+    #[serde(default = "default_auth_api_allowments")]
+    pub allow_login: bool,
+    #[serde(default = "default_auth_api_allowments")]
+    pub allow_registration: bool,
 }
 
 pub struct ServiceState<I, S, A> {
@@ -118,4 +122,9 @@ pub async fn login() -> Html<&'static str> {
 
 pub async fn handle_global_fallback() -> StatusCode {
     StatusCode::NOT_FOUND
+}
+
+#[inline(always)]
+fn default_auth_api_allowments() -> bool {
+    true
 }

--- a/freighter-server/tests/common/mod.rs
+++ b/freighter-server/tests/common/mod.rs
@@ -154,6 +154,8 @@ impl Default for ServiceStateBuilder {
                 download_endpoint: "localhost:4000".to_owned(),
                 api_endpoint: "localhost:5000".to_owned(),
                 metrics_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 3001),
+                allow_login: true,
+                allow_registration: true,
             },
             index: Default::default(),
             storage: Default::default(),

--- a/freighter-server/tests/e2e.rs
+++ b/freighter-server/tests/e2e.rs
@@ -72,6 +72,8 @@ fn server(
         download_endpoint: format!("{}/downloads/{{crate}}/{{version}}", config.server_addr),
         api_endpoint: config.server_addr.to_owned(),
         metrics_address: "127.0.0.1:9999".parse()?,
+        allow_login: true,
+        allow_registration: true,
     };
 
     let router = freighter_server::router(service, index_client, storage_client, auth_client);


### PR DESCRIPTION
There are good reasons to potentially want to lock down registrations in particular.