### PR TITLE
index: squash several more bugs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [registries]
-freighter = { index = "sparse+https://127.0.0.1:3000/index/" }
+freighter = { index = "sparse+http://127.0.0.1:3000/index/" }

--- a/freighter-index/sql/confirm-existence.sql
+++ b/freighter-index/sql/confirm-existence.sql
@@ -3,3 +3,4 @@ from crates
          join crate_versions cv on crates.id = cv.crate
 where crates.name = $1
   and cv.version = $2
+  and crates.registry = ''

--- a/freighter-index/sql/list.sql
+++ b/freighter-index/sql/list.sql
@@ -5,7 +5,7 @@ select c.name,
        c.repository,
        c.created_at,
        c.updated_at,
-       array_agg(cv.version)                                              as versions,
+       array_agg(distinct cv.version)                                     as versions,
        array_agg(distinct cat.name) filter ( where cat.name is not null ) as categories,
        array_agg(distinct k.name) filter ( where k.name is not null )     as keywords
 from crates c

--- a/freighter-index/sql/search.sql
+++ b/freighter-index/sql/search.sql
@@ -1,7 +1,7 @@
 select crates.name,
        crates.description,
-       array_agg(cv.version) as versions,
-       count(dependency)
+       array_agg(distinct cv.version) as versions,
+       count(distinct concat(d.dependent, crates.id))
 from crates
          join crate_versions cv on crates.id = cv.crate
          left join dependencies d on crates.id = d.dependency

--- a/freighter-index/sql/set-yank.sql
+++ b/freighter-index/sql/set-yank.sql
@@ -2,6 +2,7 @@ update crate_versions cv
 set yanked = $3
 from crates c
 where c.name = $1
+  and c.registry = ''
   and cv.crate = c.id
   and cv.version = $2
 returning c.name, cv.version, cv.yanked;

--- a/freighter/Cargo.toml
+++ b/freighter/Cargo.toml
@@ -9,7 +9,6 @@ repository = "https://github.com/cloudflare/freighter"
 description = "Crate index traits and implementations for the freighter registry"
 categories = ["asynchronous", "authentication"]
 keywords = ["registries", "freighter"]
-readme = "../README.md"
 
 [dependencies]
 freighter-auth = { workspace = true, features = ["pg-backend"] }


### PR DESCRIPTION
- remove freighter readme from toml so that more tools work
- don't return duplicate versions from the list_all endpoint
- fix error in test config.toml
- fix broken search sorting
- ensure people cant yank or attempt to pull crates that aren't actually in the registry