### PR TITLE
index: unconditionally populate created_at

### DIFF
--- a/freighter-index/sql/publish/insert-dependency.sql
+++ b/freighter-index/sql/publish/insert-dependency.sql
@@ -1,4 +1,5 @@
-with ins as (insert into crates (name, registry) values ($1, $2) on conflict do nothing returning id),
+with ins
+         as (insert into crates (name, registry, created_at) values ($1, $2, current_timestamp) on conflict do nothing returning id),
      dependency_crate as
          (select id
           from ins


### PR DESCRIPTION
Migrations from one registry to another get much easier if created_at is unconditionally populated, as republishes no longer have to occur in order.