### PR TITLE
config: add bucket environment variable secrets

### DIFF
--- a/crates/freighter/src/config.rs
+++ b/crates/freighter/src/config.rs
@@ -18,6 +18,6 @@ pub struct StoreConfig {
     pub name: String,
     pub endpoint_url: String,
     pub region: String,
-    pub access_key_id: String,
-    pub access_key_secret: String,
+    pub access_key_id: Option<String>,
+    pub access_key_secret: Option<String>,
 }


### PR DESCRIPTION
Add environment variables which can contain secrets for s3 API stuff as an alternative to putting secrets in yaml.