### PR TITLE
storage: make the healthchecks only read rather than write

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1027,7 +1027,6 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "freighter-api-types",
- "rand",
  "tempfile",
  "thiserror",
  "tracing",

--- a/crates/freighter-storage/Cargo.toml
+++ b/crates/freighter-storage/Cargo.toml
@@ -26,7 +26,6 @@ bytes = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-rand.workspace = true
 
 [lints]
 workspace = true

--- a/crates/freighter-storage/src/s3_client.rs
+++ b/crates/freighter-storage/src/s3_client.rs
@@ -147,12 +147,11 @@ impl S3StorageProvider {
                 Ok(obj) => {
                     if obj.as_ref() == b"ok" {
                         return Ok(());
-                    } else {
-                        // this case will not attempt to repair the data - if corruption is
-                        // occurring healthchecks should contineu to fail until manual intervention
-                        // occurs
-                        bail!("wrong data");
                     }
+
+                    // this case will not attempt to repair the data - if corruption is occurring
+                    // healthchecks should continue to fail until manual intervention occurs
+                    bail!("wrong data");
                 }
                 Err(e) => {
                     if matches!(e, StorageError::NotFound) {
@@ -169,11 +168,11 @@ impl S3StorageProvider {
                         .await?;
 
                         continue;
-                    } else {
-                        // if we failed to contact the bucket or anything else happened other than
-                        // not seeing the specific object, fail the check
-                        bail!(e);
                     }
+
+                    // if we failed to contact the bucket or anything else happened other than not
+                    // seeing the specific object, fail the check
+                    bail!(e);
                 }
             }
         }


### PR DESCRIPTION
Mutations are more costly than reads and should be generally avoided.

This change causes the service to only attempt a read from the bucket, as all we care about here is verifying connectivity and basic access anyways.

This also reverts commit 3fa03fc4ec64954682d5da2849453d6cec331f42, as this change solves the same issue a better way.