### PR TITLE
Improve client conformance to config.json

### DIFF
--- a/crates/freighter-server/tests/e2e.rs
+++ b/crates/freighter-server/tests/e2e.rs
@@ -75,7 +75,10 @@ fn server(
 
     let service = ServiceConfig {
         address: config.server_addr.parse()?,
-        download_endpoint: format!("http://{}/downloads/", config.server_addr),
+        download_endpoint: format!(
+            "http://{}/downloads/{{crate}}/{{version}}",
+            config.server_addr
+        ),
         api_endpoint: format!("http://{}", config.server_addr.to_owned()),
         metrics_address: "127.0.0.1:9999".parse()?,
         allow_registration: true,


### PR DESCRIPTION
This change makes the client use auth when specified by the registry, and obeys markers in URLs when present.

We still lack support for the sha256-checksum marker, but this requires a public API change to support.