### PR TITLE
Increase API payload limit to 16MiB

### DIFF
--- a/crates/freighter-server/tests/common/mod.rs
+++ b/crates/freighter-server/tests/common/mod.rs
@@ -198,6 +198,7 @@ impl Default for ServiceStateBuilder {
                 metrics_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 3001),
                 allow_registration: true,
                 auth_required: false,
+                crate_size_limit: 1024 * 1024,
             },
             index: Default::default(),
             storage: Default::default(),

--- a/crates/freighter-server/tests/e2e.rs
+++ b/crates/freighter-server/tests/e2e.rs
@@ -80,6 +80,7 @@ fn server(
         metrics_address: "127.0.0.1:9999".parse()?,
         allow_registration: true,
         auth_required: config.auth_required,
+        crate_size_limit: 1024 * 1024,
     };
 
     let router = freighter_server::router(service, index_client, storage_client, auth_client);


### PR DESCRIPTION
Limit is configurable if this is either too high or too low for your own requirements. Closes #60.