### PR TITLE
RUST-77: implement list api (/all) for the FS-based index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -906,6 +906,7 @@ dependencies = [
  "postgres-types",
  "semver",
  "serde",
+ "serde_json",
  "thiserror",
  "tracing",
 ]
@@ -961,6 +962,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ description = "Cloudflare's third-party Rust registry implementation"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cloudflare/freighter"
-publish = ["crates-io", "freighter", "freighter-staging"]
+publish = ["crates-io", "freighter", "freighter-staging", "freighter-local"]
 keywords = ["registries", "freighter"]
 categories = []
 

--- a/configs/local.s3-based.yaml
+++ b/configs/local.s3-based.yaml
@@ -1,0 +1,22 @@
+service:
+  address: 0.0.0.0:8080
+  download_endpoint: 127.0.0.1:8080/downloads/{crate}/{version}
+  api_endpoint: 127.0.0.1:8080
+  metrics_address: 0.0.0.0:8081
+  auth_required: false
+
+index_s3:
+  name: "crates"
+  endpoint_url: "http://127.0.0.1:9090"
+  region: "us-east-1"
+  access_key_id: "1234567890"
+  access_key_secret: "valid-secret"
+
+store:
+  name: "crates"
+  endpoint_url: "http://127.0.0.1:9090"
+  region: "us-east-1"
+  access_key_id: "1234567890"
+  access_key_secret: "valid-secret"
+
+auth_allow_full_access_without_any_checks: true

--- a/crates/freighter-api-types/Cargo.toml
+++ b/crates/freighter-api-types/Cargo.toml
@@ -17,7 +17,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 auth = []
-index = ["dep:chrono", "dep:semver", "dep:axum", "dep:anyhow", "dep:thiserror", "dep:async-trait", "dep:tracing", "dep:serde"]
+index = ["dep:chrono", "dep:semver", "dep:axum", "dep:anyhow", "dep:thiserror", "dep:async-trait", "dep:tracing", "dep:serde", "dep:serde_json"]
 storage = ["dep:axum", "dep:anyhow", "dep:async-trait", "dep:bytes", "dep:thiserror", "dep:tracing"]
 ownership = []
 
@@ -34,6 +34,7 @@ bytes = { workspace = true, optional = true }
 chrono = { workspace = true, optional = true }
 postgres-types = { workspace = true, optional = true, features = ["derive", "with-chrono-0_4"] }
 serde = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
 semver = { workspace = true, optional = true }
 thiserror = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }

--- a/crates/freighter-api-types/src/index/error.rs
+++ b/crates/freighter-api-types/src/index/error.rs
@@ -26,6 +26,13 @@ impl From<StorageError> for IndexError {
     }
 }
 
+#[cfg(feature = "index")]
+impl From<serde_json::Error> for IndexError {
+    fn from(error: serde_json::Error) -> Self {
+        IndexError::ServiceError(error.into())
+    }
+}
+
 impl IntoResponse for IndexError {
     fn into_response(self) -> Response {
         let code = match &self {

--- a/crates/freighter-api-types/src/index/request.rs
+++ b/crates/freighter-api-types/src/index/request.rs
@@ -2,11 +2,10 @@ use super::DependencyKind;
 use semver::{Version, VersionReq};
 #[cfg(feature = "server")]
 use serde::Deserialize;
-#[cfg(feature = "client")]
 use serde::Serialize;
 use std::collections::HashMap;
 
-#[cfg_attr(feature = "client", derive(Serialize))]
+#[derive(Clone, Serialize)]
 #[cfg_attr(feature = "server", derive(Deserialize))]
 pub struct Publish {
     /// The name of the package.
@@ -75,7 +74,32 @@ pub struct Publish {
     pub links: Option<String>,
 }
 
-#[cfg_attr(feature = "client", derive(Serialize))]
+impl Publish {
+    #[must_use]
+    pub fn empty() -> Publish {
+        Publish {
+            name: String::default(),
+            vers: Version::new(0, 0, 0),
+            deps: Vec::default(),
+            features: HashMap::default(),
+            authors: Vec::default(),
+            description: None,
+            documentation: None,
+            homepage: None,
+            readme: None,
+            readme_file: None,
+            keywords: Vec::default(),
+            categories: Vec::default(),
+            license: None,
+            license_file: None,
+            repository: None,
+            badges: None,
+            links: None,
+        }
+    }
+}
+
+#[derive(Clone, Serialize)]
 #[cfg_attr(feature = "server", derive(Deserialize))]
 pub struct PublishDependency {
     /// Name of the dependency.

--- a/crates/freighter-api-types/src/index/response.rs
+++ b/crates/freighter-api-types/src/index/response.rs
@@ -9,7 +9,10 @@ use std::collections::HashMap;
 
 #[cfg_attr(feature = "client", derive(Deserialize))]
 #[cfg_attr(feature = "server", derive(Serialize))]
-#[cfg_attr(any(feature = "client", feature = "server"), serde(rename_all = "kebab-case"))]
+#[cfg_attr(
+    any(feature = "client", feature = "server"),
+    serde(rename_all = "kebab-case")
+)]
 pub struct RegistryConfig {
     pub dl: String,
     pub api: String,
@@ -140,6 +143,7 @@ pub struct Dependency {
     pub package: Option<String>,
 }
 
+#[derive(Default)]
 #[cfg_attr(feature = "client", derive(Deserialize))]
 #[cfg_attr(feature = "server", derive(Serialize))]
 pub struct ListAll {

--- a/crates/freighter-api-types/src/storage/mod.rs
+++ b/crates/freighter-api-types/src/storage/mod.rs
@@ -38,12 +38,6 @@ pub trait MetadataStorageProvider {
     async fn pull_file(&self, path: &str) -> StorageResult<Bytes>;
     async fn put_file(&self, path: &str, file_bytes: Bytes, meta: Metadata) -> StorageResult<()>;
     async fn delete_file(&self, path: &str) -> StorageResult<()>;
-    async fn create_or_append_file(
-        &self,
-        path: &str,
-        append_file_bytes: Bytes,
-        meta_on_create: Metadata,
-    ) -> StorageResult<()>;
-
+    async fn list_prefix(&self, path: &str) -> StorageResult<Vec<String>>;
     async fn healthcheck(&self) -> anyhow::Result<()>;
 }

--- a/crates/freighter-fs-index/Cargo.toml
+++ b/crates/freighter-fs-index/Cargo.toml
@@ -11,7 +11,7 @@ publish.workspace = true
 repository.workspace = true
 
 [dependencies]
-freighter-api-types = { workspace = true, features = ["index", "storage"] }
+freighter-api-types = { workspace = true, features = ["index", "storage", "server"] }
 freighter-storage = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
@@ -19,7 +19,8 @@ semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
-chrono = { workspace = true }
+tracing = { workspace = true }
+chrono = { workspace = true, features = ["clock"] }
 
 [lints]
 workspace = true

--- a/crates/freighter-fs-index/src/lib.rs
+++ b/crates/freighter-fs-index/src/lib.rs
@@ -1,7 +1,10 @@
+use anyhow::Context;
 use async_trait::async_trait;
+use chrono::Utc;
 use freighter_api_types::index::request::{ListQuery, Publish};
 use freighter_api_types::index::response::{
-    CompletedPublication, CrateVersion, Dependency, ListAll, SearchResults,
+    CompletedPublication, CrateVersion, Dependency, ListAll, ListAllCrateEntry,
+    ListAllCrateVersion, SearchResults,
 };
 use freighter_api_types::index::{IndexError, IndexProvider, IndexResult};
 use freighter_api_types::storage::MetadataStorageProvider;
@@ -9,26 +12,31 @@ use freighter_storage::fs::FsStorageProvider;
 use freighter_storage::s3_client::S3StorageProvider;
 use semver::Version;
 use serde::Deserialize;
+use std::cmp::Reverse;
 use std::collections::HashMap;
 use std::future::Future;
 use std::io;
 use std::path::PathBuf;
 use std::pin::Pin;
+use std::sync::Arc;
+use tokio::task::JoinSet;
 
 mod file_locks;
 use file_locks::{AccessLocks, CrateMetaPath};
 
+use crate::file_locks::deserialize_data;
+
 pub struct FsIndexProvider {
     meta_file_locks: AccessLocks<String>,
-    fs: Box<dyn MetadataStorageProvider + Send + Sync>,
+    fs: Arc<dyn MetadataStorageProvider + Send + Sync>,
 }
 
 impl FsIndexProvider {
     pub fn new(config: Config) -> IndexResult<Self> {
         let fs = match config {
-            Config::Path(root) => Box::new(FsStorageProvider::new(root)?)
-                as Box<dyn MetadataStorageProvider + Send + Sync>,
-            Config::S3(c) => Box::new(S3StorageProvider::new(
+            Config::Path(root) => Arc::new(FsStorageProvider::new(root)?)
+                as Arc<dyn MetadataStorageProvider + Send + Sync>,
+            Config::S3(c) => Arc::new(S3StorageProvider::new(
                 &c.name,
                 &c.endpoint_url,
                 &c.region,
@@ -67,13 +75,13 @@ impl FsIndexProvider {
         let lock = self.access_crate(crate_name)?;
         let meta = lock.exclusive().await;
 
-        let mut releases = meta.deserialized().await?;
+        let (mut releases, publish) = meta.deserialized().await?;
         let release = releases
             .iter_mut()
             .rfind(|v| &v.vers == version)
             .ok_or(IndexError::NotFound)?;
         release.yanked = yank;
-        meta.replace(&releases).await
+        meta.replace(&releases, publish.as_ref()).await
     }
 
     fn is_valid_crate_file_name_char(c: u8) -> bool {
@@ -152,6 +160,7 @@ impl IndexProvider for FsIndexProvider {
             .await
             .deserialized()
             .await
+            .map(|(versions, _)| versions)
     }
 
     async fn confirm_existence(&self, crate_name: &str, version: &Version) -> IndexResult<bool> {
@@ -159,7 +168,8 @@ impl IndexProvider for FsIndexProvider {
             .shared()
             .await
             .deserialized()
-            .await?
+            .await
+            .map(|(versions, _)| versions)?
             .iter()
             .rfind(|e| &e.vers == version)
             .map(|e| e.yanked)
@@ -176,14 +186,14 @@ impl IndexProvider for FsIndexProvider {
 
     async fn publish(
         &self,
-        p: &Publish,
+        publish: &Publish,
         checksum: &str,
         end_step: Pin<&mut (dyn Future<Output = IndexResult<()>> + Send)>,
     ) -> IndexResult<CompletedPublication> {
         let release = CrateVersion {
-            name: p.name.clone(),
-            vers: p.vers.clone(),
-            deps: p
+            name: publish.name.clone(),
+            vers: publish.vers.clone(),
+            deps: publish
                 .deps
                 .iter()
                 .map(|d| {
@@ -206,9 +216,9 @@ impl IndexProvider for FsIndexProvider {
                 })
                 .collect(),
             cksum: checksum.into(),
-            features: p.features.clone(),
+            features: publish.features.clone(),
             yanked: false,
-            links: p.links.clone(),
+            links: publish.links.clone(),
             v: 2,
             features2: HashMap::default(),
         };
@@ -216,33 +226,108 @@ impl IndexProvider for FsIndexProvider {
         let lock = self.access_crate(&release.name)?;
         let meta = lock.exclusive().await;
 
-        match meta.deserialized().await {
-            Ok(existing_releases) => {
+        let mut versions = match meta.deserialized().await {
+            Ok((existing_releases, _)) => {
                 if existing_releases.iter().any(|v| v.vers == release.vers) {
                     return Err(IndexError::Conflict(format!(
                         "{}-{} aleady exists",
-                        p.name, p.vers
+                        publish.name, publish.vers
                     )));
                 }
+
+                existing_releases
             }
-            Err(IndexError::NotFound) => {}
+            Err(IndexError::NotFound) => vec![],
             Err(other) => return Err(other),
         };
+        versions.push(release);
 
         end_step.await?;
-        meta.create_or_append(&release).await?;
+
+        meta.put_index_file(&versions, publish).await?;
         Ok(CompletedPublication { warnings: None })
     }
 
     async fn list(&self, _pagination: &ListQuery) -> IndexResult<ListAll> {
-        Err(IndexError::ServiceError(
-            io::Error::from(io::ErrorKind::Unsupported).into(),
-        ))
+        let index_keys = self.fs.list_prefix("index/").await?;
+
+        let mut crate_versions_with_publish =
+            get_latest_crate_publishes(Arc::clone(&self.fs)).await?;
+        let mut results = Vec::with_capacity(index_keys.len());
+
+        while let Some(handle) = crate_versions_with_publish.join_next().await {
+            let publish_fetch_result = handle.context("index fetch task unexpectedly failed")?;
+
+            match publish_fetch_result {
+                Ok((versions, publish)) => {
+                    let entry = convert_publish_to_crate_entry(versions, publish);
+                    results.push(entry);
+                }
+                Err(error) => {
+                    tracing::error!(%error, "failed to get Publish information for crate");
+                }
+            }
+        }
+
+        Ok(ListAll { results })
     }
 
     async fn search(&self, _query_string: &str, _limit: usize) -> IndexResult<SearchResults> {
         Err(IndexError::ServiceError(
             io::Error::from(io::ErrorKind::Unsupported).into(),
         ))
+    }
+}
+
+async fn get_latest_crate_publishes(
+    fs: Arc<dyn MetadataStorageProvider + Send + Sync>,
+) -> IndexResult<JoinSet<IndexResult<(Vec<CrateVersion>, Option<Publish>)>>> {
+    let index_keys = fs.list_prefix("index/").await?;
+    let mut join_set = JoinSet::new();
+
+    for index_key in index_keys {
+        let fs = Arc::clone(&fs);
+        join_set.spawn(async move {
+            let (versions, publish) = fs
+                .pull_file(&index_key)
+                .await
+                .map(|bytes| deserialize_data(&bytes))?
+                .context("deserializing index file for list")?;
+
+            Ok((versions, publish))
+        });
+    }
+
+    Ok(join_set)
+}
+
+fn convert_publish_to_crate_entry(
+    mut versions: Vec<CrateVersion>,
+    publish: Option<Publish>,
+) -> ListAllCrateEntry {
+    versions.sort_by_key(|v| Reverse(v.vers.clone()));
+
+    let publish = publish.unwrap_or_else(|| Publish {
+        name: versions[0].name.to_string(),
+        vers: versions[0].vers.clone(),
+        ..Publish::empty()
+    });
+
+    ListAllCrateEntry {
+        name: publish.name.clone(),
+        versions: versions
+            .into_iter()
+            .map(|version| ListAllCrateVersion {
+                version: version.vers,
+            })
+            .collect(),
+        description: publish.description.unwrap_or_default(),
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        homepage: publish.homepage.clone(),
+        repository: publish.repository.clone(),
+        documentation: publish.documentation.clone(),
+        keywords: publish.keywords.clone(),
+        categories: publish.categories.clone(),
     }
 }

--- a/crates/freighter-server/tests/e2e.rs
+++ b/crates/freighter-server/tests/e2e.rs
@@ -303,13 +303,13 @@ async fn e2e_publish_crate_in_index(
         .await
         .unwrap();
 
+    // 6. List crates - unsupported
+
     // 5. Fetch our crate
     let body = freighter_client
         .download_crate(&crate_to_publish, &Version::new(1, 2, 3))
         .await
         .unwrap();
-
-    // 6. List crates - unsupported
 
     // 7. Fetch index for crate
     let index = freighter_client

--- a/crates/freighter-storage/src/fs.rs
+++ b/crates/freighter-storage/src/fs.rs
@@ -3,7 +3,7 @@ use freighter_api_types::storage::{
     Bytes, Metadata, MetadataStorageProvider, StorageError, StorageResult,
 };
 use std::io;
-use std::io::{Seek, Write};
+use std::io::Write;
 use std::path::PathBuf;
 use tempfile::NamedTempFile;
 
@@ -43,20 +43,15 @@ impl MetadataStorageProvider for FsStorageProvider {
         }
         let mut tmp = NamedTempFile::new_in(parent)?;
         tmp.write_all(&file_bytes)?;
-        tmp.persist(path).map_err(|e| StorageError::ServiceError(e.into()))?;
+        tmp.persist(path)
+            .map_err(|e| StorageError::ServiceError(e.into()))?;
         Ok(())
     }
 
-    async fn create_or_append_file(&self, path: &str, file_bytes: Bytes, _meta: Metadata) -> StorageResult<()> {
-        let path = self.abs_path(path)?;
-        let parent = path.parent().unwrap();
-        if !parent.exists() {
-            std::fs::create_dir_all(parent)?;
-        }
-        let mut file = std::fs::OpenOptions::new().create(true).append(true).open(path)?;
-        file.seek(io::SeekFrom::End(0))?;
-        file.write_all(&file_bytes)?;
-        Ok(())
+    async fn list_prefix(&self, _path: &str) -> StorageResult<Vec<String>> {
+        Err(StorageError::ServiceError(anyhow::anyhow!(
+            "list_prefix is unimplemented for the FsStorageProvider"
+        )))
     }
 
     async fn delete_file(&self, path: &str) -> StorageResult<()> {

--- a/crates/freighter-storage/src/s3_client.rs
+++ b/crates/freighter-storage/src/s3_client.rs
@@ -121,6 +121,7 @@ impl S3StorageProvider {
         for (k, v) in meta.kv {
             obj = obj.metadata(k, v);
         }
+
         obj.send().await.context("Failed to put file")?;
         Ok(())
     }
@@ -178,6 +179,25 @@ impl S3StorageProvider {
         // transient and only happen briefly when initially standing up the service with EC stores
         bail!("successfully put object but saw NotFound on pull 3 times");
     }
+
+    async fn list_prefix(&self, index: &str) -> StorageResult<Vec<String>> {
+        let objects = self
+            .client
+            .list_objects()
+            .bucket(self.bucket_name.clone())
+            .prefix(index)
+            .send()
+            .await
+            .context("failed to list all files")?;
+
+        let keys = objects
+            .contents()
+            .iter()
+            .filter_map(|obj| obj.key().map(String::from))
+            .collect();
+
+        Ok(keys)
+    }
 }
 
 #[async_trait]
@@ -190,19 +210,8 @@ impl MetadataStorageProvider for S3StorageProvider {
         self.put_object(path.into(), file_bytes.into(), meta).await
     }
 
-    async fn create_or_append_file(
-        &self,
-        path: &str,
-        file_bytes: Bytes,
-        meta: Metadata,
-    ) -> StorageResult<()> {
-        let mut all_data = match self.pull_object(path.into()).await {
-            Ok(data) => Vec::from(data),
-            Err(StorageError::NotFound) => Vec::new(),
-            Err(e) => return Err(e),
-        };
-        all_data.append(&mut Vec::from(file_bytes));
-        self.put_object(path.into(), all_data.into(), meta).await
+    async fn list_prefix(&self, path: &str) -> StorageResult<Vec<String>> {
+        self.list_prefix(path).await
     }
 
     async fn delete_file(&self, path: &str) -> StorageResult<()> {


### PR DESCRIPTION
This commit implements the /all endpoint for fs-based indexes.

We append to the end of an index entry the latest publish. That publish data contains the latest relevant metadata for a crate.

The only thing that is missing is proper `created_at` and `updated_at` dates. That can be added in a later PR.

We remove the `create_or_append` api. We simply use a ready-copy-update approach instead.

A get to `/all` locally looks like this:
```
{
  "results": [
    {
      "name": "freighter-api-types",
      "versions": [
        {
          "version": "1.0.0"
        }
      ],
      "description": "Cloudflare's third-party Rust registry implementation",
      "created_at": "2024-08-08T12:43:35.293249Z",
      "updated_at": "2024-08-08T12:43:35.293250Z",
      "homepage": null,
      "repository": "https://github.com/cloudflare/freighter",
      "documentation": null,
      "keywords": [
        "registries",
        "freighter"
      ],
      "categories": []
    }
  ]
}
```