### PR TITLE
Add missing JSON response bodies to index API

### DIFF
--- a/crates/freighter-api-types/src/index/response.rs
+++ b/crates/freighter-api-types/src/index/response.rs
@@ -264,3 +264,16 @@ impl CrateVersion {
         }
     }
 }
+
+#[cfg_attr(feature = "client", derive(Deserialize))]
+#[cfg_attr(feature = "server", derive(Serialize))]
+pub struct YankResult {
+    // Indicates the operation succeeded, always true.
+    pub ok: bool,
+}
+
+impl Default for YankResult {
+    fn default() -> Self {
+        Self { ok: true, }
+    }
+}

--- a/crates/freighter-api-types/src/ownership.rs
+++ b/crates/freighter-api-types/src/ownership.rs
@@ -1,10 +1,36 @@
 pub mod response {
     #[cfg_attr(feature = "client", derive(serde::Deserialize))]
     #[cfg_attr(feature = "server", derive(serde::Serialize))]
+    pub struct OwnerList {
+        // Array of owners of the crate.
+        pub users: Vec<ListedOwner>,
+    }
+
+    #[cfg_attr(feature = "client", derive(serde::Deserialize))]
+    #[cfg_attr(feature = "server", derive(serde::Serialize))]
     pub struct ListedOwner {
+        // Unique unsigned 32-bit integer of the owner.
         pub id: u32,
+        // The unique username of the owner.
         pub login: String,
+        // Name of the owner.
         #[cfg_attr(any(feature = "client", feature = "server"), serde(default))]
         pub name: Option<String>,
+    }
+
+    #[cfg_attr(feature = "client", derive(serde::Deserialize))]
+    #[cfg_attr(feature = "server", derive(serde::Serialize))]
+    pub struct ChangedOwnership {
+        // Indicates the operation succeeded, always true.
+        pub ok: bool,
+        // A string to be displayed to the user.
+        pub msg: String,
+    }
+
+    impl ChangedOwnership {
+        #[must_use]
+        pub fn with_msg(msg: String) -> Self {
+            Self { ok: true, msg, }
+        }
     }
 }


### PR DESCRIPTION
Right now, cargo prints out a raw serde error when, e.g., trying to yank a crate from freighter. This is despite the 200 response code returned by freighter. This PR adds the missing JSON bodies to ensure cargo properly reports successful operations.

See https://doc.rust-lang.org/cargo/reference/registry-web-api.html for the API spec.